### PR TITLE
Move from slf4j-android to android-logger.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     compile 'org.mongodb:mongo-java-driver:2.10.1'
     compile 'joda-time:joda-time:2.5'
     compile 'com.google.guava:guava:18.0'
-    compile 'org.slf4j:slf4j-android:1.7.7'
+    compile 'com.noveogroup.android:android-logger:1.3.4'
 
     compile 'com.embarkmobile:zxing-android-minimal:2.0.0@aar'
     compile 'com.embarkmobile:zxing-android-legacy:2.0.0@aar'

--- a/app/src/main/resources/android-logger.properties
+++ b/app/src/main/resources/android-logger.properties
@@ -1,0 +1,2 @@
+root=ERROR:com.nightscout.android:%logger{-2}:
+logger.com.nightscout=WARN:com.nightscout.android:%logger{-2}:


### PR DESCRIPTION
AndroidLogger is more flexible than slf4j-android, and allows us to set
per-package logging cutoffs. Also, it is smaller in size.
