### PR TITLE
Add the ability to run `./gradlew clean core:bintrayUpload` in order to

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,6 +19,8 @@ android {
         applicationId "com.nightscout.android"
         minSdkVersion 12
         targetSdkVersion 18
+        versionName rootProject.versionName
+        versionCode rootProject.versionCode
     }
 
     lintOptions {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.nightscout.android"
-    android:versionCode="17"
-    android:versionName="0.1.11-dev">
+    android:versionName="">
 
     <uses-feature android:name="android.hardware.usb.host" />
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,28 @@
-apply plugin: 'jacoco'
-
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+ext.versionName="0.1.11-dev"
+ext.versionCode=17
+
 buildscript {
     repositories {
         jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.0'
     }
 }
+
+apply plugin: 'jacoco'
 
 allprojects {
     repositories {
         jcenter()
     }
+
+    apply plugin: 'idea'
+
+    group = 'com.nightscout.android'
+    version = rootProject.versionName
 }
 
 subprojects {
@@ -28,6 +37,5 @@ subprojects {
             }
         }
     }
-
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,4 +1,6 @@
 apply plugin: 'java'
+apply plugin: 'maven-publish'
+apply plugin: 'com.jfrog.bintray'
 
 sourceCompatibility = JavaVersion.VERSION_1_7
 targetCompatibility = JavaVersion.VERSION_1_7
@@ -37,5 +39,51 @@ jacocoTestReport {
         html.enabled = true
         xml.enabled = true
         csv.enabled = false
+    }
+}
+
+// custom tasks for creating source/javadoc jars
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+// add javadoc/source jar tasks as artifacts
+artifacts {
+    archives sourcesJar, javadocJar
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+
+            artifact sourcesJar {
+                classifier "sources"
+            }
+
+            artifact javadocJar {
+                classifier "javadoc"
+            }
+        }
+    }
+}
+
+bintray {
+    user = bintrayUser  //this usually comes form gradle.properties file in ~/.gradle
+    key = bintrayKey //this usually comes form gradle.properties file in ~/.gradle
+    publications = ['mavenJava'] // see publications closure
+    pkg { //package will be created if does not exist
+        repo = 'android-uploader'
+        userOrg = 'nightscout' // an optional organization name when the repo belongs to one of the user's orgs
+        name = 'core'
+        desc = 'Nightscout core library, containing all non-android specific code.'
+        licenses = ['GPLv3']
+        labels = ['android', 'java', 'nightscout']
     }
 }


### PR DESCRIPTION
get jar in https://bintray.com/nightscout/android-uploader.

Tested:
  Manually. See:
  https://bintray.com/nightscout/android-uploader/core/0.1.11-dev/view

@ktind @rnpenguin 