### PR TITLE
Allow upload implementation to decide whether to upload all data in one request

### DIFF
--- a/app/src/main/java/com/nightscout/android/upload/Uploader.java
+++ b/app/src/main/java/com/nightscout/android/upload/Uploader.java
@@ -145,10 +145,7 @@ public class Uploader {
         for (BaseUploader uploader : uploaders) {
             // TODO(klee): capture any exceptions here so that all configured uploaders will attempt
             // to upload
-            allSuccessful &= uploader.uploadGlucoseDataSets(glucoseDataSets);
-            allSuccessful &= uploader.uploadMeterRecords(meterRecords);
-            allSuccessful &= uploader.uploadCalRecords(calRecords);
-            allSuccessful &= uploader.uploadDeviceStatus(deviceStatus);
+            allSuccessful &= uploader.uploadRecords(glucoseDataSets, meterRecords, calRecords, deviceStatus);
         }
 
         // Force a failure if an uploader was not properly initialized, but only after the other

--- a/core/src/main/java/com/nightscout/core/upload/BaseUploader.java
+++ b/core/src/main/java/com/nightscout/core/upload/BaseUploader.java
@@ -125,4 +125,20 @@ public abstract class BaseUploader {
     protected NightscoutPreferences getPreferences() {
         return this.preferences;
     }
+
+    /**
+     * Upload records, can be overridden to send all data in one batch.
+     * @param glucoseDataSets
+     * @param meterRecords
+     * @param calRecords
+     * @param deviceStatus
+     * @return True if the (all) uploads was successful or False if at least one upload was unsuccessful.
+     */
+    public boolean uploadRecords(List<GlucoseDataSet> glucoseDataSets, List<MeterEntry> meterRecords, List<CalibrationEntry> calRecords, AbstractUploaderDevice deviceStatus) {
+        boolean allSuccessful = uploadGlucoseDataSets(glucoseDataSets);
+        allSuccessful &= uploadMeterRecords(meterRecords);
+        allSuccessful &= uploadCalRecords(calRecords);
+        allSuccessful &= uploadDeviceStatus(deviceStatus);
+        return allSuccessful;
+    }
 }


### PR DESCRIPTION
Seems inefficient to do one HTTP request per glucose value, and shouldn't the decision how to upload data be in the upload implementation?