### PR TITLE
Beta to fix suspected SSL library issue.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,26 +4,27 @@ buildscript {
     }
 
     dependencies {
-        classpath 'org.robolectric:robolectric-gradle-plugin:0.14.0'
+        //classpath 'org.robolectric:robolectric-gradle-plugin:0.14.0'
+        //classpath 'org.robolectric:robolectric:3.0'
     }
 }
 
 apply plugin: 'com.android.application'
-apply plugin: 'robolectric'
+//apply plugin: 'robolectric'
 
 def gitSha = 'git rev-parse --short HEAD'.execute([], project.rootDir).text.trim()
 def buildTime = new Date().format("yyyy-MM-dd'T'HH:mm'Z'", TimeZone.getTimeZone("UTC"))
 def codeName = "Dreamsicle"
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion '21.1.1'
+    compileSdkVersion 23
+    buildToolsVersion '23.0.0'
     defaultConfig {
         applicationId "com.nightscout.android"
         minSdkVersion 12
         targetSdkVersion 18
-        versionCode 22
-        versionName "0.1.13"
+        versionCode 23
+        versionName "0.1.14-alpha"
         buildConfigField "String", "GIT_SHA", "\"${gitSha}\""
         buildConfigField "String", "BUILD_TIME", "\"${buildTime}\""
         buildConfigField "String", "VERSION_CODENAME", "\"${codeName}\""
@@ -53,12 +54,15 @@ android {
             setRoot('src/test')
         }
     }
+    useLibrary 'org.apache.http.legacy'
 }
 
-robolectric {
-    include '**/*Test.class'
-    exclude '**/espresso/**/*.class'
-}
+//testCompile 'org.roboelectric:roboelectric:3.0'
+
+//robolectric {
+//    include '**/*Test.class'
+//    exclude '**/espresso/**/*.class'
+//}
 
 repositories {
     maven { url "https://raw.github.com/embarkmobile/zxing-android-minimal/mvn-repo/maven-repository/" }
@@ -77,7 +81,8 @@ dependencies {
     compile 'com.android.support:appcompat-v7:20.0.0'
     compile 'com.android.support:support-v4:20.0.0'
     compile 'com.google.android.gms:play-services-base:6.5.87'
-    compile 'org.mongodb:mongo-java-driver:2.10.1'
+    //compile 'org.mongodb:mongo-java-driver:2.10.1'
+    compile 'org.mongodb:mongo-java-driver:3.1.0'
     compile 'net.danlew:android.joda:2.6.0'
     compile 'com.google.guava:guava:18.0'
 //    compile 'com.noveogroup.android:android-logger:1.3.4'
@@ -110,6 +115,7 @@ dependencies {
         exclude module: 'wagon-http-lightweight'
         exclude module: 'wagon-provider-api'
     }
+    testCompile 'org.robolectric:robolectric:3.0'
 }
 
 apply plugin: 'idea'
@@ -122,7 +128,7 @@ idea {
 
 // Force 'app:test' to run after 'core:test'. This way, we fail fast if something is broken with
 // core.
-test.mustRunAfter ":core:test"
+//test.mustRunAfter ":core:test"
 
 apply plugin: 'jacoco'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,7 +24,7 @@ android {
         minSdkVersion 12
         targetSdkVersion 18
         versionCode 23
-        versionName "0.1.14-alpha"
+        versionName "0.1.14-beta"
         buildConfigField "String", "GIT_SHA", "\"${gitSha}\""
         buildConfigField "String", "BUILD_TIME", "\"${buildTime}\""
         buildConfigField "String", "VERSION_CODENAME", "\"${codeName}\""

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,8 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        //classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.android.tools.build:gradle:1.3.0'
     }
 }
 

--- a/core/src/main/java/com/nightscout/core/upload/AbstractRestUploader.java
+++ b/core/src/main/java/com/nightscout/core/upload/AbstractRestUploader.java
@@ -9,10 +9,11 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.message.AbstractHttpMessage;
+import java.net.URL;
+import java.net.URI;
 import org.json.JSONObject;
 
 import java.io.IOException;
-import java.net.URI;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,5 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+#distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-all.zip


### PR DESCRIPTION
Must be built with SDK 23 or later.  
Uses org.apache.http.legacy library, as org.apache.htttp is now deprecated.  This does not fix what needs to be done to remove the deprecated methods, only allows the build to succeed and the app to function until this is done.
SSL is now the built against the new SDK SSL library.
Robolectric is included in the new way, since SDK 22.  Allows the build and tests to be run.

Honestly, I am no android or java expert, so there are likely more things to be done.  Initial testing of the Alpha was successful in the small sample of users thus far.  No unexpected crashes in tracepot.
